### PR TITLE
fix ugly error when using a wrong filename pattern

### DIFF
--- a/bots/communication.py
+++ b/bots/communication.py
@@ -706,7 +706,7 @@ class _comsession(object):
             else:
                 ta.datetime = datetime.datetime.now()
         try:
-            tofilename = tofilename.format(**ta.__dict__)   #do the actual formatting 
+            tofilename = tofilename.format(infile=ta.infilename,**ta.__dict__)   #do the actual formatting 
         except:
             txt = botslib.txtexc()
             raise botslib.CommunicationOutError(_('Error in formatting outgoing filename "%(filename)s". Error: "%(error)s".'),


### PR DESCRIPTION
**c7d96af**
in the case that the user writes the wrong filename_mask, bots ends with an ugly error, that the ta_to variable is not defined (wich is used in the catch/else clause).

p.s.: I only fixed this for sftp ...

**a4a2d1e**
see ticket #374 