### PR TITLE
http/https correction

### DIFF
--- a/bots/botslib.py
+++ b/bots/botslib.py
@@ -865,7 +865,7 @@ class Uri(object):
         fullhost = self._uri['hostname'] + port if self._uri['hostname'] else ''
         authority = '//' + userinfo + fullhost if fullhost else ''
         if self._uri['path'] or self._uri['filename']:
-            terug = os.path.join(authority,self._uri['path'],self._uri['filename'])
+            terug = authority + '/' + self._uri['path'] + '/' + self._uri['filename'])
         else:
             terug = authority
         return scheme + terug


### PR DESCRIPTION
removing os.pathJoin, removing authority on certain condition

For example :
https://scsanctions.un.org/al-qaida/
Channel type : https
Host : scsanctions.un.org
Port : 443
Path : al-qaida 

Give the following error :
MissingSchema: Invalid URL 'https:/al-qaida/': No schema supplied. Perhaps you meant http://https:/al-qaida/?
--


