### PR TITLE
enable support for JSON data types other than string 

### DIFF
--- a/bots/grammar.py
+++ b/bots/grammar.py
@@ -902,6 +902,18 @@ class x12(Grammar):
             else:
                 field[DECIMALS] = 0
 class json(Grammar):
+    formatconvert = {
+        'A':'A',        #alfanumerical
+        'AN':'A',       #alfanumerical
+        'B':'B',    #BOOLEAN = custom
+        'D':'D',        #date
+        'DT':'D',       #date-time
+        'T':'T',        #time
+        'TM':'T',       #time
+        'N':'N',        #numerical, fixed decimal. Fixed nr of decimals; if no decimal used: whole number, integer
+        'R':'R',        #numerical, any number of decimals; the decimal point is 'floating'
+        'I':'I',        #numercial, implicit decimal
+        }
     defaultsyntax = {
         'charset':'utf-8',
         'checkcharsetin':'strict', #strict, ignore or botsreplace (replace with char as set in bots.ini).

--- a/bots/message.py
+++ b/bots/message.py
@@ -206,7 +206,7 @@ class Message(object):
             if field_definition[ISFIELD]:    #if field (no composite)
                 if field_definition[MAXREPEAT] == 1:    #if non-repeating
                     value = noderecord.get(field_definition[ID])
-                    if not value:
+                    if value is None:
                         if field_definition[MANDATORY]:
                             self.add2errorlist(_('[F02]%(linpos)s: Record "%(mpath)s" field "%(field)s" is mandatory.\n')%
                                                 {'linpos':node_instance.linpos(),'mpath':self.mpathformat(record_definition[MPATH]),'field':field_definition[ID]})

--- a/bots/message.py
+++ b/bots/message.py
@@ -424,6 +424,12 @@ class Message(object):
             raise botslib.MappingRootError(_('put(%(mpath)s): "root" of outgoing message is empty; use out.putloop'),
                                             {'mpath':mpaths})
         return self.root.put(*mpaths,**kwargs)
+    
+    def putraw(self,*mpaths,**kwargs):
+        if self.root.record is None and self.root.children:
+            raise botslib.MappingRootError(_(u'put(%(mpath)s): "root" of outgoing message is empty; use out.putloop'),
+                                            {'mpath':mpaths})
+        return self.root.putraw(*mpaths,**kwargs)
 
     def putloop(self,*mpaths):
         if not self.root.record:    #no input yet, and start with a putloop(): dummy root

--- a/bots/node.py
+++ b/bots/node.py
@@ -441,6 +441,41 @@ class Node(object):
         botsglobal.logmap.debug('"True" for put %(mpaths)s',{'mpaths':unicode(mpaths)})
         return True
 
+    def putraw(self,*mpaths,**kwargs):
+        #sanity check of mpaths
+        if not mpaths or not isinstance(mpaths,tuple):
+            raise botslib.MappingFormatError(_(u'Must be dicts in tuple: put(%(mpath)s)'),{'mpath':mpaths})
+        for part in mpaths:
+            if not isinstance(part,dict):
+                raise botslib.MappingFormatError(_(u'Must be dicts in tuple: put(%(mpath)s)'),{'mpath':mpaths})
+            if 'BOTSID' not in part:
+                raise botslib.MappingFormatError(_(u'Section without "BOTSID": put(%(mpath)s)'),{'mpath':mpaths})
+            for key,value in part.iteritems():
+                if value is None:
+                    botsglobal.logmap.debug(u'"None" in put %(mpaths)s.',{'mpaths':unicode(mpaths)})
+                    return False
+                if not isinstance(key,basestring):
+                    raise botslib.MappingFormatError(_(u'Keys must be strings: put(%(mpath)s)'),{'mpath':mpaths})
+                if isinstance(value,list):
+                    #empty is not useful, drop it (like None)
+                    if not value:
+                        botsglobal.logmap.debug(u'Empty list in put %(mpaths)s.',{'mpaths':unicode(mpaths)})
+                        return False
+                #else: #no conversion to unicode string
+                #    if kwargs.get('strip',True):
+                #        part[key] = unicode(value).strip()  #leading and trailing spaces are stripped from the values
+                #    else:
+                #        part[key] = unicode(value)          #used for fixed ISA header of x12
+            if 'BOTSIDnr' not in part:
+                part['BOTSIDnr'] = u'1'
+
+        if self._sameoccurence(mpaths[0]):
+            self._putcore(mpaths[1:])
+        else:
+            raise botslib.MappingRootError(_(u'Error in root put "%(mpath)s".'),{'mpath':mpaths[0]})
+        botsglobal.logmap.debug(u'"True" for put %(mpaths)s',{'mpaths':unicode(mpaths)})
+        return True
+    
     def _putcore(self,mpaths):
         if not mpaths:  #newmpath is exhausted, stop searching.
             return

--- a/bots/outmessage.py
+++ b/bots/outmessage.py
@@ -258,7 +258,7 @@ class Outmessage(message.Message):
 
 
     def _formatfield(self,value, field_definition,structure_record,node_instance):
-        ''' Input: value (as a string) and field definition.
+        ''' Input: value (normally a string, except for putraw() under JSON) and field definition.
             Some parameters of self.syntax are used, eg decimaal
             Format is checked and converted (if needed).
             return the formatted value
@@ -275,6 +275,10 @@ class Outmessage(message.Message):
             if len(value) < field_definition[MINLENGTH]:
                 self.add2errorlist(_('[F21]: Record "%(record)s" field "%(field)s" too small (min %(min)s): "%(content)s".\n')%
                                     {'record':self.mpathformat(structure_record[MPATH]),'field':field_definition[ID],'content':value,'min':field_definition[MINLENGTH]})
+        elif field_definition[BFORMAT] == 'B': #Boolean (json)
+            if not isinstance(value, bool):
+                self.add2errorlist(_(u'[F35]: Record "%(record)s" field "%(field)s" is not of type bool.\n')%
+                                    {'record':self.mpathformat(structure_record[MPATH]),'field':field_definition[ID],'content':value})
         elif field_definition[BFORMAT] in 'DT':
             lenght = len(value)
             if field_definition[BFORMAT] == 'D':
@@ -311,7 +315,7 @@ class Outmessage(message.Message):
                 if lenght < field_definition[MINLENGTH]:
                     self.add2errorlist(_('[F34]: Record "%(record)s" time field "%(field)s" too small (min %(min)s): "%(content)s".\n')%
                                         {'record':self.mpathformat(structure_record[MPATH]),'field':field_definition[ID],'content':value,'min':field_definition[MINLENGTH]})
-        else:   #numerics
+        elif isinstance(value, unicode): #only if text, not when a raw numeric value is given (putraw() json)
             #~ if value[0] == '-':
                 #~ minussign = '-'
                 #~ absvalue = value[1:]

--- a/bots/outmessage.py
+++ b/bots/outmessage.py
@@ -315,7 +315,7 @@ class Outmessage(message.Message):
                 if lenght < field_definition[MINLENGTH]:
                     self.add2errorlist(_('[F34]: Record "%(record)s" time field "%(field)s" too small (min %(min)s): "%(content)s".\n')%
                                         {'record':self.mpathformat(structure_record[MPATH]),'field':field_definition[ID],'content':value,'min':field_definition[MINLENGTH]})
-        elif isinstance(value, unicode): #only if text, not when a raw numeric value is given (putraw() json)
+        elif isinstance(value, basestring): #only if text, not when a raw numeric value is given (putraw() json)
             #~ if value[0] == '-':
                 #~ minussign = '-'
                 #~ absvalue = value[1:]


### PR DESCRIPTION
Hi Henk-Jan,

In most output types everything needs to be converted to text, but for JSON output, in order to be able to write true and false values for example, not every value may be converted to text.
The solution of these changes: a putraw() function which allows these values to be passed on to the JSON writer.